### PR TITLE
Add webFetch tool for testing Claude Desktop integration

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 import type { ToolRegistration } from "@/types";
 import { someFunctionTool } from "./exampleTool";
+import { webFetchTool } from "./webFetch";
 
 // biome-ignore lint/suspicious/noExplicitAny: Any is fine here because all tools validate their input schemas.
 export const createTools = (): ToolRegistration<any>[] => {
@@ -8,6 +9,11 @@ export const createTools = (): ToolRegistration<any>[] => {
 			...someFunctionTool,
 			// biome-ignore lint/suspicious/noExplicitAny: All tools validate their input schemas, so any is fine.
 			handler: (args: any) => someFunctionTool.handler(args),
+		},
+		{
+			...webFetchTool,
+			// biome-ignore lint/suspicious/noExplicitAny: All tools validate their input schemas, so any is fine.
+			handler: (args: any) => webFetchTool.handler(args),
 		},
 	];
 };

--- a/src/tools/webFetch/index.ts
+++ b/src/tools/webFetch/index.ts
@@ -1,0 +1,56 @@
+import type { ToolRegistration } from "@/types";
+import { makeJsonSchema } from "@/utils/makeJsonSchema";
+import { type WebFetchSchema, webFetchSchema } from "./schema";
+
+export const webFetch = async (args: WebFetchSchema): Promise<string> => {
+  try {
+    const { url, method, headers } = args;
+    
+    // Using native fetch API
+    const response = await fetch(url, {
+      method,
+      headers: headers || {},
+    });
+    
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+    
+    const data = await response.text();
+    return data.substring(0, 1000); // Limit response size
+  } catch (error) {
+    console.error("Error in webFetch:", error);
+    throw new Error(`Failed to fetch data: ${(error as Error).message}`);
+  }
+};
+
+export const webFetchTool: ToolRegistration<WebFetchSchema> = {
+  name: "web_fetch",
+  description: "Fetches data from a specified URL and returns the content",
+  inputSchema: makeJsonSchema(webFetchSchema),
+  handler: async (args: WebFetchSchema) => {
+    try {
+      const parsedArgs = webFetchSchema.parse(args);
+      const result = await webFetch(parsedArgs);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      console.error("Error in webFetchTool handler:", error);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${(error as Error).message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};

--- a/src/tools/webFetch/schema.ts
+++ b/src/tools/webFetch/schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const webFetchSchema = z.object({
+  url: z.string().url("Valid URL is required").describe("The URL to fetch data from"),
+  method: z.enum(["GET", "POST"]).default("GET").describe("HTTP method to use for the request"),
+  headers: z.record(z.string()).optional().describe("Optional HTTP headers to include"),
+});
+
+export type WebFetchSchema = z.infer<typeof webFetchSchema>;

--- a/src/tools/webFetch/webFetch.test.ts
+++ b/src/tools/webFetch/webFetch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, mock } from "bun:test";
+import { webFetch } from "./index";
+import { webFetchSchema } from "./schema";
+
+// Mock the global fetch function
+global.fetch = mock(() =>
+  Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve("Success response"),
+  } as Response)
+);
+
+describe("webFetch Tool", () => {
+  it("should parse valid input", () => {
+    const result = webFetchSchema.safeParse({ url: "https://example.com" });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject invalid URLs", () => {
+    const result = webFetchSchema.safeParse({ url: "not-a-url" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should handle the main function", async () => {
+    const output = await webFetch({ url: "https://example.com", method: "GET" });
+    expect(output).toBe("Success response");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This PR adds a simple web fetcher tool to test the MCP server integration with Claude Desktop.

Changes:
- Added a new `webFetch` tool that can fetch content from URLs
- Updated server name to "SVerse Web Tools"
- Added enhanced logging to help troubleshoot communication issues
- The tool validates URLs and handles errors appropriately

To use this with Claude Desktop:
1. Build the project: `bun run build`
2. Add the server to Claude Desktop's config with this tool
3. You should see the `web_fetch` tool available in Claude

This implementation follows best practices from other successful MCP servers, focusing on proper schema descriptions, error handling, and naming conventions.
