### PR TITLE
Add Supabase database tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.1.1",
+    "@supabase/supabase-js": "^2.38.4",
     "@types/json-schema": "^7.0.15",
     "pretty-js-log": "^1.1.1",
     "zod": "^3.24.1",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 import type { ToolRegistration } from "@/types";
 import { someFunctionTool } from "./exampleTool";
+import { supabaseDbTool } from "./supabaseDb";
 import { webFetchTool } from "./webFetch";
 
 // biome-ignore lint/suspicious/noExplicitAny: Any is fine here because all tools validate their input schemas.
@@ -14,6 +15,11 @@ export const createTools = (): ToolRegistration<any>[] => {
 			...webFetchTool,
 			// biome-ignore lint/suspicious/noExplicitAny: All tools validate their input schemas, so any is fine.
 			handler: (args: any) => webFetchTool.handler(args),
+		},
+		{
+			...supabaseDbTool,
+			// biome-ignore lint/suspicious/noExplicitAny: All tools validate their input schemas, so any is fine.
+			handler: (args: any) => supabaseDbTool.handler(args),
 		},
 	];
 };

--- a/src/tools/supabaseDb/index.ts
+++ b/src/tools/supabaseDb/index.ts
@@ -1,0 +1,113 @@
+import type { ToolRegistration } from "@/types";
+import { makeJsonSchema } from "@/utils/makeJsonSchema";
+import { getSupabaseClient } from "@/utils/supabaseClient";
+import { 
+  type SupabaseDbSchema, 
+  type SupabaseQuerySchema, 
+  type SupabaseInsertSchema,
+  supabaseDbSchema 
+} from "./schema";
+
+// Handle a database query operation
+export const querySupabase = async (params: SupabaseQuerySchema): Promise<Record<string, any>[]> => {
+  try {
+    const supabase = getSupabaseClient();
+    const { table, select, filter, limit } = params;
+
+    // Start building the query
+    let query = supabase.from(table).select(select);
+
+    // Apply filter if provided
+    if (filter) {
+      const { column, operator, value } = filter;
+      query = query.filter(column, operator, value);
+    }
+
+    // Apply limit if provided
+    if (limit) {
+      query = query.limit(limit);
+    }
+
+    // Execute the query
+    const { data, error } = await query;
+
+    if (error) {
+      throw new Error(`Database query error: ${error.message}`);
+    }
+
+    return data || [];
+  } catch (error) {
+    console.error("Error in querySupabase:", error);
+    throw new Error(`Failed to query database: ${(error as Error).message}`);
+  }
+};
+
+// Handle a database insert operation
+export const insertSupabase = async (params: SupabaseInsertSchema): Promise<Record<string, any>> => {
+  try {
+    const supabase = getSupabaseClient();
+    const { table, data } = params;
+
+    // Perform the insert
+    const { data: result, error } = await supabase.from(table).insert(data).select();
+
+    if (error) {
+      throw new Error(`Database insert error: ${error.message}`);
+    }
+
+    return result?.[0] || { success: true };
+  } catch (error) {
+    console.error("Error in insertSupabase:", error);
+    throw new Error(`Failed to insert data: ${(error as Error).message}`);
+  }
+};
+
+// Handle both operations
+export const supabaseDb = async (args: SupabaseDbSchema): Promise<Record<string, any>> => {
+  try {
+    const { operation, params } = args;
+
+    if (operation === "query") {
+      return { rows: await querySupabase(params) };
+    } else if (operation === "insert") {
+      return { result: await insertSupabase(params) };
+    }
+
+    throw new Error(`Unknown operation: ${operation}`);
+  } catch (error) {
+    console.error("Error in supabaseDb:", error);
+    throw new Error(`Database operation failed: ${(error as Error).message}`);
+  }
+};
+
+export const supabaseDbTool: ToolRegistration<SupabaseDbSchema> = {
+  name: "supabase_db",
+  description: "Perform operations on the Supabase database",
+  inputSchema: makeJsonSchema(supabaseDbSchema),
+  handler: async (args: SupabaseDbSchema) => {
+    try {
+      const parsedArgs = supabaseDbSchema.parse(args);
+      const result = await supabaseDb(parsedArgs);
+      
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      console.error("Error in supabaseDbTool handler:", error);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${(error as Error).message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};

--- a/src/tools/supabaseDb/schema.ts
+++ b/src/tools/supabaseDb/schema.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+// Query schema for querying data from a Supabase table
+export const supabaseQuerySchema = z.object({
+  table: z.string().min(1).describe("The name of the table to query"),
+  select: z.string().default("*").describe("Columns to select (default: all columns)"),
+  filter: z.object({
+    column: z.string().describe("Column name to filter on"),
+    operator: z.enum([
+      "eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in", "contains"
+    ]).describe("Filter operator (eq, neq, gt, gte, lt, lte, like, ilike, is, in, contains)"),
+    value: z.any().describe("Value to compare against")
+  }).optional().describe("Optional filter criteria"),
+  limit: z.number().int().positive().max(1000).optional().describe("Maximum number of rows to return")
+});
+
+// Insert schema for adding data to a Supabase table
+export const supabaseInsertSchema = z.object({
+  table: z.string().min(1).describe("The name of the table to insert into"),
+  data: z.record(z.any()).describe("The data to insert as a key-value object")
+});
+
+// Combined schema that accepts either a query or insert operation
+export const supabaseDbSchema = z.discriminatedUnion("operation", [
+  z.object({
+    operation: z.literal("query").describe("Perform a database query operation"),
+    params: supabaseQuerySchema.describe("Query parameters")
+  }),
+  z.object({
+    operation: z.literal("insert").describe("Perform a database insert operation"),
+    params: supabaseInsertSchema.describe("Insert parameters")
+  })
+]);
+
+export type SupabaseDbSchema = z.infer<typeof supabaseDbSchema>;
+export type SupabaseQuerySchema = z.infer<typeof supabaseQuerySchema>;
+export type SupabaseInsertSchema = z.infer<typeof supabaseInsertSchema>;

--- a/src/tools/supabaseDb/supabaseDb.test.ts
+++ b/src/tools/supabaseDb/supabaseDb.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { supabaseDb } from "./index";
+import { supabaseDbSchema } from "./schema";
+import * as supabaseClient from "@/utils/supabaseClient";
+
+// Mock data
+const mockData = [
+  { id: 1, name: "Test Item 1" },
+  { id: 2, name: "Test Item 2" }
+];
+
+// Mock Supabase client
+const mockFrom = mock(() => ({
+  select: mock(() => ({
+    filter: mock(() => ({
+      limit: mock(() => ({
+        then: mock(() => Promise.resolve({ data: mockData, error: null }))
+      })),
+      then: mock(() => Promise.resolve({ data: mockData, error: null }))
+    })),
+    limit: mock(() => ({
+      then: mock(() => Promise.resolve({ data: mockData, error: null }))
+    })),
+    then: mock(() => Promise.resolve({ data: mockData, error: null }))
+  })),
+  insert: mock(() => ({
+    select: mock(() => ({
+      then: mock(() => Promise.resolve({ data: [{ id: 3, name: "New Item" }], error: null }))
+    }))
+  }))
+}));
+
+// Mock getSupabaseClient
+const mockSupabaseClient = {
+  from: mockFrom
+};
+
+describe("supabaseDb Tool", () => {
+  // Mock the getSupabaseClient function
+  spyOn(supabaseClient, "getSupabaseClient").mockReturnValue(mockSupabaseClient as any);
+
+  it("should parse valid query input", () => {
+    const result = supabaseDbSchema.safeParse({
+      operation: "query",
+      params: { table: "items", select: "*" }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should parse valid insert input", () => {
+    const result = supabaseDbSchema.safeParse({
+      operation: "insert",
+      params: { table: "items", data: { name: "Test Item" } }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should handle query operation", async () => {
+    const output = await supabaseDb({
+      operation: "query",
+      params: { table: "items", select: "*" }
+    });
+    
+    expect(output).toHaveProperty("rows");
+    expect(mockFrom).toHaveBeenCalledWith("items");
+  });
+
+  it("should handle insert operation", async () => {
+    const output = await supabaseDb({
+      operation: "insert",
+      params: { table: "items", data: { name: "New Item" } }
+    });
+    
+    expect(output).toHaveProperty("result");
+    expect(mockFrom).toHaveBeenCalledWith("items");
+  });
+});

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,0 +1,18 @@
+import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// The Supabase URL and public key are from the project settings
+// Hardcoded for now, but could be moved to environment variables
+const supabaseUrl = "https://rkmjjhjjpnhjymqmcvpe.supabase.co";
+const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJrbWpqaGpqcG5oanltcW1jdnBlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY4MzM5NDUsImV4cCI6MjA2MjQwOTk0NX0.GlxA96751aHLq0Bi6nhKXtWHF0tlmWvsemGr3heQ13k";
+
+// Create a single supabase client and export it
+let _supabaseClient: SupabaseClient | null = null;
+
+export const getSupabaseClient = (): SupabaseClient => {
+  if (!_supabaseClient) {
+    _supabaseClient = createClient(supabaseUrl, supabaseKey);
+    console.error("Supabase client initialized");
+  }
+  return _supabaseClient;
+};


### PR DESCRIPTION
This PR adds a Supabase database tool to interact with your Supabase PostgreSQL database.

## Features
- Connect to Supabase using the project URL and public key
- Query data from tables with filtering and limiting options
- Insert data into tables

## Implementation Details
- Added `@supabase/supabase-js` dependency
- Created a Supabase client utility for connection management
- Implemented a tool with discriminated union for query and insert operations
- Added proper schema validation with Zod
- Includes unit tests

## Setup Required
Before using this tool, you'll need to create at least one table in your Supabase database. You can do this through the Supabase dashboard.

## Usage Examples
Once merged and rebuilt, you can use the tool like this:

1. Query data:
```
{
  "operation": "query",
  "params": {
    "table": "your_table_name",
    "select": "*",
    "filter": {
      "column": "name",
      "operator": "eq",
      "value": "something"
    },
    "limit": 10
  }
}
```

2. Insert data:
```
{
  "operation": "insert",
  "params": {
    "table": "your_table_name",
    "data": {
      "name": "New Item",
      "description": "This is a new item"
    }
  }
}
```