### PR TITLE
Replace Supabase tool with simple Echo tool

### DIFF
--- a/src/tools/echoTool/echoTool.test.ts
+++ b/src/tools/echoTool/echoTool.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { echo } from "./index";
+import { echoSchema } from "./schema";
+
+describe("echo Tool", () => {
+  it("should parse valid input", () => {
+    const result = echoSchema.safeParse({ message: "Hello World" });
+    expect(result.success).toBe(true);
+  });
+
+  it("should echo the message back as-is", () => {
+    const output = echo({ message: "Hello World", uppercase: false });
+    expect(output).toBe("Hello World");
+  });
+
+  it("should echo the message back in uppercase", () => {
+    const output = echo({ message: "Hello World", uppercase: true });
+    expect(output).toBe("HELLO WORLD");
+  });
+});

--- a/src/tools/echoTool/index.ts
+++ b/src/tools/echoTool/index.ts
@@ -1,0 +1,44 @@
+import type { ToolRegistration } from "@/types";
+import { makeJsonSchema } from "@/utils/makeJsonSchema";
+import { type EchoSchema, echoSchema } from "./schema";
+
+export const echo = (args: EchoSchema): string => {
+  try {
+    const { message, uppercase } = args;
+    return uppercase ? message.toUpperCase() : message;
+  } catch (error) {
+    console.error("Error in echo:", error);
+    throw new Error(`Failed to process message: ${(error as Error).message}`);
+  }
+};
+
+export const echoTool: ToolRegistration<EchoSchema> = {
+  name: "echo",
+  description: "Simply echoes back the message you send",
+  inputSchema: makeJsonSchema(echoSchema),
+  handler: (args: EchoSchema) => {
+    try {
+      const parsedArgs = echoSchema.parse(args);
+      const result = echo(parsedArgs);
+      return {
+        content: [
+          {
+            type: "text",
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      console.error("Error in echoTool handler:", error);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${(error as Error).message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};

--- a/src/tools/echoTool/schema.ts
+++ b/src/tools/echoTool/schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const echoSchema = z.object({
+  message: z.string().describe("The message to echo back"),
+  uppercase: z.boolean().default(false).describe("Whether to convert the message to uppercase")
+});
+
+export type EchoSchema = z.infer<typeof echoSchema>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,6 @@
 import type { ToolRegistration } from "@/types";
+import { echoTool } from "./echoTool";
 import { someFunctionTool } from "./exampleTool";
-import { supabaseDbTool } from "./supabaseDb";
 import { webFetchTool } from "./webFetch";
 
 // biome-ignore lint/suspicious/noExplicitAny: Any is fine here because all tools validate their input schemas.
@@ -17,9 +17,9 @@ export const createTools = (): ToolRegistration<any>[] => {
 			handler: (args: any) => webFetchTool.handler(args),
 		},
 		{
-			...supabaseDbTool,
+			...echoTool,
 			// biome-ignore lint/suspicious/noExplicitAny: All tools validate their input schemas, so any is fine.
-			handler: (args: any) => supabaseDbTool.handler(args),
+			handler: (args: any) => echoTool.handler(args),
 		},
 	];
 };


### PR DESCRIPTION
This PR replaces the complex Supabase tool with a simple Echo tool to help debug tool visibility issues.

The Echo tool is extremely simple - it just echoes back any message you send it, optionally converting it to uppercase. It follows the exact same pattern as the working tools (some_function and web_fetch).

## Implementation
- Created a simple tool with just two parameters: `message` and `uppercase`
- All schema fields have proper descriptions
- Tool uses the same structure as the working tools
- Removed the more complex Supabase tool temporarily to isolate the issue

## Testing Steps
1. Merge this PR
2. Checkout and pull the updated main branch
3. Run `bun install` and `bun run build`
4. Start the server with `node dist/main.js`
5. Open Claude Desktop and check if all three tools show up

If this simpler tool shows up in Claude Desktop, it will confirm that the issue was with the complexity of the Supabase tool's schema. If it still doesn't show up, we'll need to investigate other potential issues.