### PR TITLE
Revert to known working state with two tools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,4 @@
 import type { ToolRegistration } from "@/types";
-import { echoTool } from "./echoTool";
 import { someFunctionTool } from "./exampleTool";
 import { webFetchTool } from "./webFetch";
 
@@ -15,11 +14,6 @@ export const createTools = (): ToolRegistration<any>[] => {
 			...webFetchTool,
 			// biome-ignore lint/suspicious/noExplicitAny: All tools validate their input schemas, so any is fine.
 			handler: (args: any) => webFetchTool.handler(args),
-		},
-		{
-			...echoTool,
-			// biome-ignore lint/suspicious/noExplicitAny: All tools validate their input schemas, so any is fine.
-			handler: (args: any) => echoTool.handler(args),
 		},
 	];
 };


### PR DESCRIPTION
This PR reverts the codebase to a known working state with just two tools (webFetch and someFunction).

When we had these two tools, Claude Desktop was able to recognize them properly. This commit:
1. Removes the echoTool and supabaseDb tool
2. Keeps only the two known working tools
3. Maintains the enhanced logging and server name settings

Next steps after this:
1. Get back to a known good state (tools showing up)
2. Add tools one at a time with careful testing between each
3. Focus on understanding what factors make Claude Desktop recognize tools

With this simplified version, we can rebuild our reliability by incrementally adding features after we confirm this baseline works.